### PR TITLE
[홈 페이지] 마크업 구현

### DIFF
--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -11,8 +11,8 @@ export function LdisabledBtn({ content }) {
   return <LdisabledBtnStyle>{content}</LdisabledBtnStyle>;
 }
 
-export function MBtn() {
-  return <MBtnStyle>팔로우</MBtnStyle>;
+export function MBtn({ h, content }) {
+  return <MBtnStyle height={h}>{content}</MBtnStyle>;
 }
 
 export function MdisabledBtn() {
@@ -76,6 +76,7 @@ const LdisabledBtnStyle = styled(BtnCommonStlyeDisabled)`
 `;
 
 const MBtnStyle = styled(BtnCommonStlye)`
+  height: ${props => props.height}px;
   width: 120px;
   padding: 5px;
 `;

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -1,7 +1,47 @@
 import React from 'react';
+import styled from 'styled-components';
+import { HeaderMainNav } from '../../components/common/Header/Header';
+import Navbar from '../../components/common/Navbar/Navbar';
+import basicLogo from '../../assets/images/logoImage.png';
+import { MBtn } from '../../components/common/button/Button';
 
 function HomePage() {
-  return <div>HomePage</div>;
+  return (
+    <Wrapper>
+      <HeaderMainNav />
+      {/* 조건식 추가 */}
+      <HomeBlank />
+      <Navbar />
+    </Wrapper>
+  );
 }
+
+function HomeBlank() {
+  return (
+    <ContentWrapper>
+      {/* 기능구현 고민된다.. */}
+      <img src={basicLogo} alt="Logo" />
+      <p>유저를 검색해 팔로우 해보세요.</p>
+      <MBtn h="44" content="검색" />
+    </ContentWrapper>
+  );
+}
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 80vh;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  img {
+    height: 100px;
+    width: 100px;
+  }
+`;
 
 export default HomePage;


### PR DESCRIPTION
## 구현내용
<img width="833" alt="image" src="https://github.com/FRONTENDSCHOOL5/final-11-NigoNego/assets/85488522/8a2860bf-baf3-4ca4-811d-75c63f305db0">

### 문제
-  컨텐츠를 가운데 정열하는데 있어서 문제가 있었음<br>=>컨텐츠 컴포넌트에 height 값을 80vh 를 주고 align-item: center 로 가운데 정렬 구현

### 요청사항
- 헤더/네비바 컨포넌트 css 수정 필요
