### PR TITLE
[리팩터링] 좋아요 API분리 에러수정

### DIFF
--- a/src/Hooks/UseFetchToken.jsx
+++ b/src/Hooks/UseFetchToken.jsx
@@ -7,7 +7,7 @@ import createAxiosInstance from '../api/Api';
 
 const UseFetchToken = () => {
   const UserToken = useRecoilValue(authAtom);
-  const { getDataBase } = createAxiosInstance(UserToken);
+  const { getDataBase, postDataBase } = createAxiosInstance(UserToken);
 
   //팔로잉 게시글 목록
   const GetHomeFeedData = async (number, skip) => {
@@ -84,6 +84,24 @@ const UseFetchToken = () => {
     }
   };
 
+  const postHeart = async id => {
+    try {
+      const response = await postDataBase.post(`/post/${id}/heart`);
+      return response;
+    } catch (error) {
+      console.error('좋아요에러', error);
+    }
+  };
+
+  const deleteHeart = async id => {
+    try {
+      const response = await postDataBase.delete(`/post/${id}/unheart`);
+      return response;
+    } catch (error) {
+      console.error('좋아요에러', error);
+    }
+  };
+
   return {
     GetHomeFeedData,
     getPostListLimit,
@@ -92,6 +110,8 @@ const UseFetchToken = () => {
     getFollowData,
     getUserFeed,
     yourAccount,
+    postHeart,
+    deleteHeart,
   };
 };
 

--- a/src/api/Api.jsx
+++ b/src/api/Api.jsx
@@ -16,9 +16,18 @@ const createAxiosInstance = token => {
     },
   });
 
+  const postDataBase = axios.create({
+    baseURL: baseUrl,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
   return {
     getDataBase,
     instance,
+    postDataBase,
   };
 };
 

--- a/src/atom/atomId.jsx
+++ b/src/atom/atomId.jsx
@@ -1,0 +1,14 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+//1. 아무것도 설정 안 하고 쓰는 경우
+//localStorage에 저장되며, key 이름은 'recoil-persist'로 저장됨
+const { persistAtom } = recoilPersist();
+
+const atomId = atom({
+  key: 'accountname',
+  default: '',
+  effects_UNSTABLE: [persistAtom],
+});
+
+export default atomId;

--- a/src/components/HomePost/HomePost.jsx
+++ b/src/components/HomePost/HomePost.jsx
@@ -1,25 +1,28 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import UserSearch from '../common/User/UserSearch';
 import { ReactComponent as BtnComment } from '../../assets/image/BtnComment.svg';
 import Heart from '../common/Heart/Heart';
+import { useRecoilState } from 'recoil';
+import atomId from '../../atom/atomId';
 
 export default function HomePost({ data }) {
-  // const [feedPost, setFeedPost] = useState('');
   const navigate = useNavigate();
   const postListRef = useRef(null);
+  const [userId, setUserId] = useRecoilState(atomId);
 
   const postMainHandler = e => {
-    // setPostId(id);
-    console.log(e.target.value);
-    console.log(data.id);
     navigate('/postmain', {
       state: {
         id: data.id,
       },
     });
   };
+
+  useEffect(() => {
+    setUserId(data);
+  }, []);
 
   return (
     <HomePostwarpper ref={postListRef} className="HomePost">
@@ -35,7 +38,7 @@ export default function HomePost({ data }) {
               <BtnComment width="24px" />
               <span>{data.commentCount}</span>
             </button>
-            <Heart />
+            <Heart userData={data} />
           </div>
           {/* <time>{data.updatedAt}</time> */}
         </section>

--- a/src/components/HomePost/MyHomePost.jsx
+++ b/src/components/HomePost/MyHomePost.jsx
@@ -73,7 +73,7 @@ export default function MyHomePost({ accountname }) {
                     <BtnComment width="24px" height="24px" stroke="#767676" />
                     <span>{data.commentCount}</span>
                   </button>
-                  <Heart />
+                  <Heart userData={data} />
                 </div>
               </div>
             </div>

--- a/src/components/common/Heart/Heart.jsx
+++ b/src/components/common/Heart/Heart.jsx
@@ -1,29 +1,38 @@
 import React, { useEffect, useState } from 'react';
 import { ReactComponent as BtnHeartF } from './../../../assets/icons/BtnHeartF.svg';
-import { PostHeartData, DeleteHeart } from '../../../api/getData/getData';
+import UseFetchToken from '../../../Hooks/UseFetchToken';
+import atomYourData from '../../../atom/atomYourData';
+import { useRecoilValue } from 'recoil';
+import atomId from '../../../atom/atomId';
 
-export default function Heart() {
-  const [like, setLike] = useState(false);
-  const [likeCount, setLikeCount] = useState('0');
+export default function Heart({ userData }) {
+  console.log(userData);
+  const [like, setLike] = useState(userData.hearted);
+  const [likeCount, setLikeCount] = useState(0);
+  const { postHeart, deleteHeart } = UseFetchToken();
 
-  function HeartCount() {
+  const HeartCount = () => {
+    setLike(!like);
+  };
+
+  useEffect(() => {
     if (like) {
-      DeleteHeart().then(response => {
-        setLike(response.data.post.hearted);
-        setLikeCount(response.data.post.heartCount);
-        console.log(response.data.post.heartCount);
-      });
+      console.log('like');
+      postHeart(userData.id).then(res =>
+        setLikeCount(res.data.post.heartCount),
+      );
+      // postHeart(userId.id).then(res => console.log(res));
     } else {
-      PostHeartData().then(response => {
-        setLike(response.data.post.hearted);
-        setLikeCount(response.data.post.heartCount);
-      });
+      // console.log('delete');
+      deleteHeart(userData.id).then(res =>
+        setLikeCount(res.data.post.heartCount),
+      );
     }
-  }
+  }, [like]);
 
+  console.log(likeCount);
   return (
     <button type="button" className="btn" onClick={HeartCount}>
-      {console.log(1111)}
       <BtnHeartF
         fill={like ? '#EF4343' : '#fff'}
         stroke={like ? '#EF4343' : '#767676'}
@@ -32,5 +41,3 @@ export default function Heart() {
     </button>
   );
 }
-
-export { Heart };

--- a/src/pages/HomeFeed/HomeFeed.jsx
+++ b/src/pages/HomeFeed/HomeFeed.jsx
@@ -25,8 +25,8 @@ function HomeFeed(props) {
   const fetchData = skip => {
     GetHomeFeedData(5, skip)
       .then(response => {
-        // console.log(response);
         setUserData(prevData => [...prevData, ...response.data.posts]);
+        console.log(userData);
       })
       .catch(error => console.error(error));
   };

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -61,7 +61,7 @@ function LoginPage() {
       FollowingData,
       setIsCorrect,
       setLoginErrMessage,
-    );
+    ).then(res => console.log(res));
   }
 
   async function FollowingData(token) {


### PR DESCRIPTION
기존 좋아요 기능은 새로고침시 좋아요 숫자가 초기화되는 오류가 있었습니다.
UseFetchToken 에   postHeart,deleteHeart API를 분리하였고 돌아오는 response데이터를 <Heart/> 컴포넌트에 연결하여
success 되었을 때 데이터를 연동시켜 기존데이터가 남아 있게 처리했습니다.

 

- [x] postHeart,deleteHeart API 분리

https://github.com/FRONTENDSCHOOL5/final-11-NigoNego/blob/35973a3900aac1363d191d3e3119d64b6f73ec29/src/Hooks/UseFetchToken.jsx#L87-L103

- [x] myHomePost 에서 Heart 컴포넌트로 데이터 넘겨주기

https://github.com/FRONTENDSCHOOL5/final-11-NigoNego/blob/35973a3900aac1363d191d3e3119d64b6f73ec29/src/components/HomePost/MyHomePost.jsx#L76


- [x] Heart 컴포넌트의 props로 받기

https://github.com/FRONTENDSCHOOL5/final-11-NigoNego/blob/35973a3900aac1363d191d3e3119d64b6f73ec29/src/components/common/Heart/Heart.jsx#L8-L13