### PR TITLE
[리팩토링] PostUpload 프로필 ui 변경

### DIFF
--- a/src/components/common/User/UserProfileCircle.jsx
+++ b/src/components/common/User/UserProfileCircle.jsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+import basicImg from '../../../assets/images/basic-profile-img.png';
+
+const UserProfileCircle = () => {
+    return (
+        <UserProfileCircleStyle style={{ backgroundImage: `url(${basicImg})`}}>
+        </UserProfileCircleStyle>
+    )
+}
+
+export default UserProfileCircle;
+
+const UserProfileCircleStyle = styled.div`
+  width: 100%;
+  aspect-ratio: 1/1;
+  border-radius: 50%;
+  background-size: cover;
+`

--- a/src/components/common/User/UserProfileCircle.jsx
+++ b/src/components/common/User/UserProfileCircle.jsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import basicImg from '../../../assets/images/basic-profile-img.png';
 
-const UserProfileCircle = () => {
+const UserProfileCircle = ({isWidth}) => {
     return (
-        <UserProfileCircleStyle style={{ backgroundImage: `url(${basicImg})`}}>
+        <UserProfileCircleStyle isWidth={isWidth} style={{ backgroundImage: `url(${basicImg})`}}>
         </UserProfileCircleStyle>
     )
 }
@@ -11,8 +11,9 @@ const UserProfileCircle = () => {
 export default UserProfileCircle;
 
 const UserProfileCircleStyle = styled.div`
-  width: 100%;
-  aspect-ratio: 1/1;
+  width: ${({isWidth}) => (isWidth ? isWidth : '100%')};
+  height: ${({isWidth}) => isWidth};
+
   border-radius: 50%;
   background-size: cover;
 `

--- a/src/pages/PostPage/PostUpload/PostUpload.jsx
+++ b/src/pages/PostPage/PostUpload/PostUpload.jsx
@@ -11,6 +11,7 @@ import authAtom from '../../../atom/authToken';
 import Layout from '../../../styles/Layout';
 import FileUploadInput from '../../../components/common/Input/FileUploadInput';
 import useFetchToken from "../../../Hooks/UseFetchToken";
+import UserProfileCircle from "../../../components/common/User/UserProfileCircle";
 export default function PostUpload() {
   const navigate = useNavigate();
   const user = 'nigonego';
@@ -60,7 +61,7 @@ export default function PostUpload() {
       <form onSubmit={handleSubmit}>
         <BodyGlobal>
           <PostUploadWrapper>
-            <SImage />
+            <UserProfileCircle isWidth="48px"/>
             <textarea
               className="inputPost"
               placeholder="게시글 입력하기"
@@ -87,16 +88,18 @@ const PostUploadWrapper = styled.div`
   /* box-shadow: inset 0 0 10px red; */
   margin-top: 10px;
   display: flex;
+  justify-content: space-between;
+  
   textarea {
-    display: block;
-    border: 0px;
-    width: 80vw;
-    min-height: 30vh;
-    padding: 12px 6px;
-    resize: none;
-    margin: auto;
-  }
+    border: none;
+    width: calc(100% - 60px);
+    min-height: 140px;
+    padding: 10px;
+    box-sizing: border-box;
+    line-height: 1.2em;
+    white-space: pre-wrap;
 `;
+
 
 const UploadImg = styled.img`
   margin-top: 10px;
@@ -109,23 +112,23 @@ const UploadImg = styled.img`
   margin-left: 53px;
 `;
 
-const UploadButtonStyle = styled.div`
-  position: fixed;
-  bottom: 16px;
-  right: 16px;
-  label {
-    width: 50px;
-    height: 50px;
-    display: inline-block;
-    background-image: url(${buttonImg});
-    background-size: cover;
-  }
-
-  input {
-    display: none;
-  }
-
-  input::file-selector-button {
-    display: none;
-  }
-`;
+// const UploadButtonStyle = styled.div`
+//   position: fixed;
+//   bottom: 16px;
+//   right: 16px;
+//   label {
+//     width: 50px;
+//     height: 50px;
+//     display: inline-block;
+//     background-image: url(${buttonImg});
+//     background-size: cover;
+//   }
+//
+//   input {
+//     display: none;
+//   }
+//
+//   input::file-selector-button {
+//     display: none;
+//   }
+// `;


### PR DESCRIPTION
기존 프로필 컴포넌트는 동일한 디자인이 여러 컴포넌트로 나뉘어 있어 재사용하지 못하는 점에서 리팩토링이 필요하다고 생각했습니다. 
따라서 UserProfileCircle이라는 새로운 프로필 컴포넌트를 만들어 페이지에 적용했습니다. 
해당 컴포넌트에서 집중한 부분은 width 값을 props로 받아와 **해당 컴포넌트를 사용하는 컴포넌트에서 width를 지정해준다**는 점이었습니다. 
이런 방법을 통해 컴포넌트 재사용성을 높였습니다. 

변한 ui는 아래와 같습니다. 
<img width="386" alt="issue173" src="https://github.com/FRONTENDSCHOOL5/final-11-NigoNego/assets/117130358/d9b04af9-d725-4e23-80ab-35d18685fc7e">
