### PR TITLE
💄 Design : #176 상단 더보기 버튼 및 토글 디자인 수정

### DIFF
--- a/src/components/common/Modal/SlideModal.jsx
+++ b/src/components/common/Modal/SlideModal.jsx
@@ -73,30 +73,39 @@ export function CommentSlideModal({ isMyComment, closeModal }) {
 }
 
 const SlideModalBackground = styled.div`
-  position: fixed;
-  display: flex;
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.2);
-  width: 100%;
+  width: 390px;
   height: 100%;
   z-index: 999;
   overflow: hidden;
 `;
 const SlideModalWrapper = styled.div`
+  /* 일단 고정 width 값으로 진행  */
+  width: 390px;
   text-align: center;
+  margin: 0 auto;
   padding: 10px 0;
   border: 1px solid var(--basic-border-color);
   border-radius: 10px 10px 0 0;
   position: fixed;
-  left: 0px;
   bottom: 1px;
   background-color: white;
-  width: 100%;
   z-index: 100;
   cursor: pointer;
+  animation: fadeInModal 0.5s ease;
+  @keyframes fadeInModal {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
 `;
 
 const StyledUl = styled.ul`

--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -80,7 +80,7 @@ export function MoreIconButton() {
 
   return (
     <>
-      <MoreIconButtonStyle onClick={handleIconClick}>
+      <MoreIconButtonStyle onClick={handleIconClick} backgroundColor="none">
         <IconMoreView width="24px" height="24px" />
       </MoreIconButtonStyle>
       {isSideSlideOpen && (
@@ -92,5 +92,4 @@ export function MoreIconButton() {
 
 export const MoreIconButtonStyle = styled.button`
   ${ButtonCommonStyle}
-  color: red;
 `;


### PR DESCRIPTION
## 상단 메뉴바 더보기 버튼 디자인 수정 
- 더보기 버튼 원래 디자인으로 수정했습니다
<img width="514" alt="스크린샷 2023-10-10 오후 2 54 39" src="https://github.com/FRONTENDSCHOOL5/final-11-NigoNego/assets/85488522/172a398b-f44e-40dd-8778-4355213f1e21">

## 토글 디자인 수정 
- 토글 레이아웃을 글로벌 레이아웃으로 맞췄습니다. 
<img width="519" alt="스크린샷 2023-10-10 오후 3 00 19" src="https://github.com/FRONTENDSCHOOL5/final-11-NigoNego/assets/85488522/52d21ba3-3418-421d-b60b-3551a7eb8e0f">

## 토글 애니메이션 추가 
- 토글 올라올때 애니메이션을 추가했습니다! 