### PR TITLE
[리팩토링] ProductUpload 페이지 헤더 변경

### DIFF
--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -17,19 +17,30 @@ export function HeaderBasicNav({ children, disabled }) {
   //주소가 postupload 일 때만 업로드 버튼 랜더링
   const pathName = window.location.pathname;
   const isPostUpLoad = pathName == '/postupload';
+  const isProductUpLoad = pathName == '/product';
 
   // 뒤로가기 버튼 구현하기;
   return (
     <HeaderDefaultStyle>
       <Arrow />
-      {!isPostUpLoad ? (
+      {(!isPostUpLoad && !isProductUpLoad) ? (
         <MoreIconButton />
       ) : (
         <ButtonShort disabled={disabled}>{children}</ButtonShort>
       )}
+
     </HeaderDefaultStyle>
   );
 }
+
+// export function HeaderUploadNav({ disabled, children }) {
+//     return (
+//         <HeaderDefaultStyle>
+//             <Arrow />
+//             <ButtonShort disabled={disabled}>{children}</ButtonShort>
+//         </HeaderDefaultStyle>
+//     );
+// }
 
 //상단 화살표 스타일
 const arrow = () => {
@@ -92,15 +103,6 @@ export function HeaderMainNav({ content }) {
   );
 }
 
-export function HeaderUploadNav(props) {
-  const { disabled, content } = props;
-  return (
-    <HeaderDefaultStyle>
-      <Arrow />
-      <ButtonShort disabled={disabled} content={content} />
-    </HeaderDefaultStyle>
-  );
-}
 
 export function HeaderEditdNav({ content, isFormValid, handleSave }) {
   return (

--- a/src/components/common/button/Button.jsx
+++ b/src/components/common/button/Button.jsx
@@ -48,11 +48,10 @@ const ButtonMiddleStyle = styled.button`
 `;
 
 // 짧은 버튼
-export const ButtonShort = props => {
-  const { disabled, handleSave, content, isFormValid } = props;
+export const ButtonShort = ({disabled, children}) => {
   return (
-    <ButtonShortStyle content={content} disabled={disabled} {...props}>
-      {props.children}
+    <ButtonShortStyle disabled={disabled}>
+      {children}
     </ButtonShortStyle>
   );
 };

--- a/src/pages/ProductPage/ProductPage.jsx
+++ b/src/pages/ProductPage/ProductPage.jsx
@@ -1,19 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import styled from 'styled-components';
 import Input from '../../components/common/Input/Input';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import BodyGlobal from '../../styles/BodyGlobal';
 import authAtom from '../../atom/authToken';
 
 import FileUploadInput from '../../components/common/Input/FileUploadInput';
-import { HeaderUploadNav } from '../../components/common/Header/Header';
+import { HeaderBasicNav } from '../../components/common/Header/Header';
 import Layout from '../../styles/Layout';
 
 import useFetchToken from "../../Hooks/UseFetchToken";
 export default function ProductPage() {
-  const user = 'nigonego';
   const navigate = useNavigate();
 
   const [itemName, setItemName] = useState('');
@@ -21,16 +18,13 @@ export default function ProductPage() {
   const [link, setLink] = useState('');
   const [itemImage, setItemImage] = useState('');
 
-  const auth = useRecoilValue(authAtom);
   const { postJoinImage, postProductUpload } = useFetchToken();
 
   const [isFormValid, setIsFormValid] = useState(false);
-  // const [isBtnActive, setIsBtnActive] = useState(Boolean(false));
 
   useEffect(() => {
     if (itemName && price && link && itemImage) {
       setIsFormValid(true);
-      // setIsBtnActive(Boolean(true))
     }
   }, [itemName, price, link, itemImage]);
 
@@ -57,7 +51,7 @@ export default function ProductPage() {
   return (
     <Layout>
       <form onSubmit={handleSubmit}>
-        <HeaderUploadNav content="업로드" isFormValid={isFormValid} />
+        <HeaderBasicNav disabled={!isFormValid}>업로드</HeaderBasicNav>
 
         <ul>
           <li>


### PR DESCRIPTION
Product 페이지 헤더를 HeaderUploadNav에서 HeaderBasicNav로 변경하였습니다. 

기존 Product 등록 페이지에서 헤더로 HeaderUploadNav를 사용하고 있었는데 다음 같은 이유로 HeaderBasicNav를 사용하는 방향이 더 적절할 거 같았습니다. 
1. 하나의 헤더 컴포넌트 활용
여러 개의 헤더 컴포넌트를 만들어 활용하는 것보다 하나의 컴포넌트를 여러 페이지에서 활용하는 방법이 컴포넌트 활용도를 높이는 방법이라고 생각했습니다. 
2. 업로드 버튼 활성화 기능 활용
폼을 채웠을 때만 업로드 버튼이 활성화되는 기능이 HeaderBasicNav 안에 있는 버튼에 적용되어 있었습니다. 

따라서 상품 등록 페이지에서 HeaderBasicNav를 사용하기 위해 HeaderBasicNav에 업로드 버튼 조건 추가하였고
그 결과 Product 페이지에서도 HeaderBasicNav를 사용할 수 있게 되었습니다.

[결과 페이지]
<img width="411" alt="상품등록페이지 헤더 변경" src="https://github.com/FRONTENDSCHOOL5/final-11-NigoNego/assets/117130358/7b56cd18-17ee-473d-b39e-ad586e3668e2">
