### PR TITLE
fix: #183 404페이지 이전으로 버튼에 기능 추가

### DIFF
--- a/src/pages/NotFound/NotFound.jsx
+++ b/src/pages/NotFound/NotFound.jsx
@@ -1,14 +1,21 @@
 import React from 'react';
-import SVG from '../../assets/images/404 page.svg';
+import NotFoundImage from '../../assets/images/404 page.svg';
 import { Image, NotFoundText, NotFoundBtn } from './NotFoundStyle';
 import Layout from "../../styles/Layout";
+import {useNavigate} from "react-router-dom";
+import styled from "styled-components";
 
 export default function NotFound() {
-  return (
-    <Layout align="center">
-      <Image src={SVG} alt="404" />
-      <NotFoundText>페이지를 찾을 수 없음</NotFoundText>
-      <NotFoundBtn>이전페이지</NotFoundBtn>
-    </Layout>
-  );
+    const navigate = useNavigate();
+    const handleBack = () => {
+        navigate(-1);
+    }
+
+    return (
+        <Layout align="center">
+            <Image src={NotFoundImage} alt="404페이지 로고" />
+            <NotFoundText>페이지를 찾을 수 없음</NotFoundText>
+            <NotFoundBtn onClick={handleBack}>이전페이지</NotFoundBtn>
+        </Layout>
+    );
 }


### PR DESCRIPTION
404페이지 이전으로 버튼을 클릭해도 함수가 동작하지 않는 이슈가 있었습니다. 
따라서 이전으로 버튼에 useNavigate를 사용하여 onClick 시 화면이 이동하도록 하는 기능을 추가했습니다. 

[고민]
해당 기능은 header에서도 공통으로 쓰이는 함수인데, 
커스텀 훅을 만들어 적용하는 방법이 더 좋지 않을까 하는 생각이 들었습니다. 